### PR TITLE
added sourcemaps to webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+    devtool: 'source-map',
     entry: './src/app.js',
     output: {
         path: __dirname,


### PR DESCRIPTION
Adds sourcemaps to devtools. This allows you to see the specific file and line an error is occurring.

![image](https://cloud.githubusercontent.com/assets/427218/22453196/ef5bc642-e731-11e6-8c66-f1186cebea1d.png)
